### PR TITLE
Fix incorrect handling of flags

### DIFF
--- a/reStream.sh
+++ b/reStream.sh
@@ -5,9 +5,8 @@ ssh_host="root@10.11.99.1" # remarkable connected trough USB
 landscape=true             # rotate 90 degrees to the right
 
 # loop through arguments and process them
-for arg in "$@"
-do
-    case $arg in
+while [ $# -gt 0 ]; do
+    case "$1" in
         -p|--portrait)
             landscape=false
             shift


### PR DESCRIPTION
Previously, arguments were examined by a for loop, but this loop is not
affected by the `shift` commands executed inside of it.

Because the loop always advances one argument further on each iteration,
this bug goes unnoticed with the `--portrait` option (`shift` is called
once, which matches the behavior of the loop). However, handling of the
`--destination` argument is broken because of that (`shift` is called
twice but the loop only advances one argument).

This commit replaces the `for` loop by a `while` loop which always
examines the next argument and properly takes `shift`s into account.
This is based on the following SO answer:
<https://stackoverflow.com/a/7069755/3452708>