### PR TITLE
Allow choosing the video output

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ reMarkable screen sharing over SSH.
 ### Options
 
 - `-p --portrait`: shows the reMarkable screen in portrait mode (the default is landscape mode, 90 degrees rotated tot the right)
-- `-d --destination`: the ssh destination of the reMarkable (default: `root@10.11.99.1`)
+- `-s --source`: the ssh destination of the reMarkable (default: `root@10.11.99.1`)
+- `-o --output`: path of the output where the video should be recorded, as understood by `ffmpeg`; if this is `-`, the video is displayed in a new window and not recorded anywhere (default: `-`)
+- `-f --format`: when recording to an output, this option is used to force the encoding format; if this is `-`, `ffmpeg`’s auto format detection based on the file extension is used (default: `-`).
 
 If you have problems, don't hesitate to [open an issue](https://github.com/rien/reStream/issues/new) or [send me an email](mailto:rien.maertens@posteo.be).
 

--- a/reStream.sh
+++ b/reStream.sh
@@ -79,12 +79,13 @@ fi
 
 
 output_args=()
+video_filters=()
 
 # calculate how much bytes the window is
 window_bytes="$(($width*$height*$bytes_per_pixel))"
 
 # rotate 90 degrees if landscape=true
-$landscape && output_args+=('-vf' 'transpose=1')
+$landscape && video_filters+=('transpose=1')
 
 # read the first $window_bytes of the framebuffer
 head_fb0="dd if=/dev/fb0 count=1 bs=$window_bytes 2>/dev/null"
@@ -103,6 +104,12 @@ else
 
     output_args+=("$output_path")
 fi
+
+# set frame presentation time to the time it was received
+video_filters+=('setpts=(RTCTIME - RTCSTART) / (TB * 1000000)')
+
+joined_filters=$(IFS=,; echo "${video_filters[*]}")
+output_args+=('-vf' "$joined_filters")
 
 set -e # stop if an error occurs
 

--- a/reStream.sh
+++ b/reStream.sh
@@ -78,14 +78,14 @@ fi
 
 
 
-output_args=()
-video_filters=()
+output_args=""
+video_filters=""
 
 # calculate how much bytes the window is
 window_bytes="$(($width*$height*$bytes_per_pixel))"
 
 # rotate 90 degrees if landscape=true
-$landscape && video_filters+=('transpose=1')
+$landscape && video_filters="$video_filters,transpose=1"
 
 # read the first $window_bytes of the framebuffer
 head_fb0="dd if=/dev/fb0 count=1 bs=$window_bytes 2>/dev/null"
@@ -99,17 +99,16 @@ else
     output_command=ffmpeg
 
     if [ "$format" != - ]; then
-        output_args+=('-f' "$format")
+        output_args="$output_args -f '$format' "
     fi
 
-    output_args+=("$output_path")
+    output_args="$output_args '$output_path'"
 fi
 
 # set frame presentation time to the time it was received
-video_filters+=('setpts=(RTCTIME - RTCSTART) / (TB * 1000000)')
+video_filters="$video_filters,setpts=(RTCTIME - RTCSTART) / (TB * 1000000)"
 
-joined_filters=$(IFS=,; echo "${video_filters[*]}")
-output_args+=('-vf' "$joined_filters")
+output_args="$output_args -vf '${video_filters#,}'"
 
 set -e # stop if an error occurs
 

--- a/reStream.sh
+++ b/reStream.sh
@@ -13,17 +13,17 @@ while [ $# -gt 0 ]; do
             landscape=false
             shift
             ;;
-        -s|--source)
+        -s | --source)
             ssh_host="$2"
             shift
             shift
             ;;
-        -o|--output)
+        -o | --output)
             output_path="$2"
             shift
             shift
             ;;
-        -f|--format)
+        -f | --format)
             format="$2"
             shift
             shift
@@ -78,8 +78,6 @@ else
     decompress="lz4 -d"
 fi
 
-
-
 # list of ffmpeg filters to apply
 video_filters=""
 
@@ -121,10 +119,10 @@ set -e # stop if an error occurs
 ssh_cmd "$read_loop" \
     | $decompress \
     | "$output_cmd" \
-             -vcodec rawvideo \
-             -loglevel "$loglevel" \
-             -f rawvideo \
-             -pixel_format gray16le \
-             -video_size "$width,$height" \
-             -i - \
-             "$@"
+        -vcodec rawvideo \
+        -loglevel "$loglevel" \
+        -f rawvideo \
+        -pixel_format gray16le \
+        -video_size "$width,$height" \
+        -i - \
+        "$@"


### PR DESCRIPTION
Instead of simply playing back the frames through `ffplay`, I thought it might be interesting to be able to record the sequence to a video file or to use it as part of a stream.

I have in mind the use case of making educational videos/live streams where the tablet can be used as a kind of remote blackboard by teachers, which is especially relevant currently. But there are certainly other use cases!

## Changes

This commit adds two new options to that effect:

* `-o --output`: Path of the output as understood by `ffmpeg` (usually a file name). If this is `-` (as it is by default), the existing behavior of playing the stream through `ffplay` is restored.

* `-f --format`: When recording to an output, this option can be used to force the encoding format. If this is `-` (again, the default), `ffmpeg`’s auto format detection is used (based on the file extension).

Because of the possible confusion between the newly added `--output` option and the existing `--destination` option for specifying the source address, I suggest renaming the `--destination` option to `--source` (this is implemented in this commit).

## Examples

### Record to a file

```sh
./reStream.sh -o remarkable.mp4
```

Caveat: The recorded file plays back too fast. I am not sure how to fix this. (Edit: Fixed, see below.)

### Create an UDP MPEG-TS stream

```sh
./reStream.sh -o "udp://127.0.0.1:1234" -f "mpegts"
```

This sends frames over UDP to the specified port using the MPEG-TS format (see <https://trac.ffmpeg.org/wiki/StreamingGuide>). This stream can then be connected, for example, to OBS for live streaming (see <https://connect.ed-diamond.com/Linux-Pratique/LP-096/Enrichir-sa-diffusion-de-contenus-multimedias-avec-OBS> in French).