### PR TITLE
Set Window Title

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ reMarkable screen sharing over SSH.
 - `-f --format`: when recording to an output, this option is used to force the encoding format; if this is `-`, `ffmpeg`’s auto format detection based on the file extension is used (default: `-`).
 - `-w --webcam`: record to a video4linux2 web cam device. By default the first found web cam is taken, this can be overwritten with `-o`. The video is scaled to 1280x720 to ensure compatibility with MS Teams, Skype for business and other programs which need this specific format.
 - `-t --throughput`: use `pv` to measure how much data throughput you have (good to experiment with parameters to speed up the pipeline)
+- `--window_title`: set a custom window title for the video stream. The default title is "reStream". This option is disabled when using `-o --output`
 
 If you have problems, don't hesitate to [open an issue](https://github.com/rien/reStream/issues/new) or [send me an email](mailto:rien.maertens@posteo.be).
 

--- a/reStream.sh
+++ b/reStream.sh
@@ -7,6 +7,7 @@ output_path=-              # display output through ffplay
 format=-                   # automatic output format
 webcam=false               # not to a webcam
 measure_throughput=false   # measure how fast data is being transferred
+window_tile=reStream       # stream windoe title is reStream
 
 # loop through arguments and process them
 while [ $# -gt 0 ]; do
@@ -55,8 +56,13 @@ while [ $# -gt 0 ]; do
             fi
             shift
             ;;
+        --window_title)
+            window_title="$2"
+            shift
+            shift
+            ;;
         -h | --help | *)
-            echo "Usage: $0 [-p] [-s <source>] [-o <output>] [-f <format>]"
+            echo "Usage: $0 [-p] [-s <source>] [-o <output>] [-f <format>] [--window_title <title>]"
             echo "Examples:"
             echo "	$0                              # live view in landscape"
             echo "	$0 -p                           # live view in portrait"
@@ -189,5 +195,6 @@ ssh_cmd "$read_loop" \
         -f rawvideo \
         -pixel_format rgb565le \
         -video_size "$width,$height" \
+        -window_title "$window_title" \
         -i - \
         "$@"

--- a/reStream.sh
+++ b/reStream.sh
@@ -173,6 +173,8 @@ set -- "$@" -vf "${video_filters#,}"
 
 if [ "$output_path" = - ]; then
     output_cmd=ffplay
+
+    window_title_option="-window_title $window_title"
 else
     output_cmd=ffmpeg
 
@@ -195,6 +197,6 @@ ssh_cmd "$read_loop" \
         -f rawvideo \
         -pixel_format rgb565le \
         -video_size "$width,$height" \
-        -window_title "$window_title" \
+        $window_title_option \
         -i - \
         "$@"

--- a/reStream.sh
+++ b/reStream.sh
@@ -7,7 +7,7 @@ output_path=-              # display output through ffplay
 format=-                   # automatic output format
 webcam=false               # not to a webcam
 measure_throughput=false   # measure how fast data is being transferred
-window_tile=reStream       # stream windoe title is reStream
+window_title=reStream      # stream window title is reStream
 
 # loop through arguments and process them
 while [ $# -gt 0 ]; do


### PR DESCRIPTION
Adds the default window title "reStream" and the option `--window_title <title>` to set a custom title.

The recording of videos is still possible. The window title option is not used when recording a video.