### PR TITLE
Use ffmpeg native options to do scaling and padding math

### DIFF
--- a/reStream.sh
+++ b/reStream.sh
@@ -142,7 +142,7 @@ $landscape && video_filters="$video_filters,transpose=1"
 # for business). Send a PR is you can get a heigher resolution working.
 if $webcam; then
     video_filters="$video_filters,format=pix_fmts=yuv420p"
-    video_filters="$video_filters,scale=-1:720"            
+    video_filters="$video_filters,scale=-1:720"
     video_filters="$video_filters,pad=1280:0:-1:0:#eeeeee"
 fi
 

--- a/reStream.sh
+++ b/reStream.sh
@@ -142,16 +142,8 @@ $landscape && video_filters="$video_filters,transpose=1"
 # for business). Send a PR is you can get a heigher resolution working.
 if $webcam; then
     video_filters="$video_filters,format=pix_fmts=yuv420p"
-    if $landscape; then
-        render_width=$((720 * height / width))
-    else
-        render_width=$((720 * width / height))
-    fi
-
-    # center
-    offset_left=$(((1280 - render_width) / 2))
-    video_filters="$video_filters,scale=${render_width}x720"
-    video_filters="$video_filters,pad=1280:720:$offset_left:0:#eeeeee"
+    video_filters="$video_filters,scale=-1:720"            
+    video_filters="$video_filters,pad=1280:0:-1:0:#eeeeee"
 fi
 
 # set each frame presentation time to the time it is received


### PR DESCRIPTION
While testing my remarkable 2, I found the scaling in webcam mode a bit off.

It turns out that we don't need to do this math at all, ffmpeg has options to scale based on one dimension and pad to center automatically.

Documentation for "pad" - https://ffmpeg.org/ffmpeg-filters.html#pad-1
Documentation for "scale" - https://ffmpeg.org/ffmpeg-filters.html#scale-1

Tested on remarkable 2 (so, merged with that branch) and a relatively modern version of ffmpeg on my machine.