### PR TITLE
Detect more rM 1 devices with debatable changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
+libremarkable = "0.4"
 lz-fear = "0.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,12 +37,6 @@ fn main() -> Result<()> {
         .context("Error while compressing framebuffer stream")
 }
 
-fn remarkable_version() -> Result<String> {
-    let content = std::fs::read("/sys/devices/soc0/machine")
-        .context("Failed to read /sys/devices/soc0/machine")?;
-    Ok(String::from_utf8(content)?)
-}
-
 fn xochitl_pid() -> Result<usize> {
     let output = Command::new("/bin/pidof")
         .args(&["xochitl"])

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 #[macro_use]
 extern crate anyhow;
-extern crate lz_fear;
 
 use anyhow::{Context, Result};
 use libremarkable::device::{CURRENT_DEVICE, Model};

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ extern crate anyhow;
 extern crate lz_fear;
 
 use anyhow::{Context, Result};
+use libremarkable::device::{CURRENT_DEVICE, Model};
 use lz_fear::CompressionSettings;
 
 use std::default::Default;
@@ -12,12 +13,12 @@ use std::process::Command;
 
 fn main() -> Result<()> {
     let version = remarkable_version()?;
-    let streamer = if version == "reMarkable 1.0\n" {
+    let streamer = if CURRENT_DEVICE.model == Model::Gen1 {
         let width = 1408;
         let height = 1872;
         let bytes_per_pixel = 2;
         ReStreamer::init("/dev/fb0", 0, width, height, bytes_per_pixel)?
-    } else if version == "reMarkable 2.0\n" {
+    } else if CURRENT_DEVICE.model == Model::Gen2 {
         let width = 1404;
         let height = 1872;
         let bytes_per_pixel = 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,26 +12,24 @@ use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::process::Command;
 
 fn main() -> Result<()> {
-    let version = remarkable_version()?;
-    let streamer = if CURRENT_DEVICE.model == Model::Gen1 {
-        let width = 1408;
-        let height = 1872;
-        let bytes_per_pixel = 2;
-        ReStreamer::init("/dev/fb0", 0, width, height, bytes_per_pixel)?
-    } else if CURRENT_DEVICE.model == Model::Gen2 {
-        let width = 1404;
-        let height = 1872;
-        let bytes_per_pixel = 1;
+    let streamer = match CURRENT_DEVICE.model {
+        Model::Gen1 => {
+            let width = 1408;
+            let height = 1872;
+            let bytes_per_pixel = 2;
+            ReStreamer::init("/dev/fb0", 0, width, height, bytes_per_pixel)?
+        },
+        Model::Gen2 => {
+            let width = 1404;
+            let height = 1872;
+            let bytes_per_pixel = 1;
 
-        let pid = xochitl_pid()?;
-        let offset = rm2_fb_offset(pid)?;
-        let mem = format!("/proc/{}/mem", pid);
-        ReStreamer::init(&mem, offset, width, height, bytes_per_pixel)?
-    } else {
-        Err(anyhow!(
-            "Unknown reMarkable version: {}\nPlease open a feature request to support your device.",
-            version
-        ))?
+            let pid = xochitl_pid()?;
+            let offset = rm2_fb_offset(pid)?;
+            let mem = format!("/proc/{}/mem", pid);
+            ReStreamer::init(&mem, offset, width, height, bytes_per_pixel)?
+        },
+        Model::Unknown => unreachable!()
     };
 
     let lz4: CompressionSettings = Default::default();


### PR DESCRIPTION
Hi,

since I heard of the recent success of reading rM 2 devices, I revisited the project once more (had used a version that was a few months old). Since I saw the rust files and am currently really into it, I took a look and found that you also had the problem of detecting the device version.

Currently some rM 1 device will not get detected since there is (to my knowledge) one additional name for reMarkable 1 devices. See @Eeems' [comment](https://github.com/Eeems/oxide/issues/48#issuecomment-698414093) (highly recommended issue to gain information regarding all kinds of rM 2 changes). He should also be able to check it and see that the binary will actually not work on his device.

Other than simply adding `reMarkable Prototype 1` to the list, I chose to use the detection from libremarkable. I added the support there as part of implementing rM 2 input for libremarkable ([PR](https://github.com/canselcik/libremarkable/pull/48)) and this implementation should get updated whenever we encounter an unsupported device. (The pr also has some discussion about what approach of model detection would be best).

While `libremarkable::framebuffer::common` provides `DISPLAYWIDTH` and `DISPLAYHEIGHT`, I didn't use them since your code is pretty readable and short and this change would harm that. They are also just constants and a potential rM 3 with a new size would introduce a breaking change there anyway (most likely constant -> lazy_static which needs a \* in front).

Advantages:
 - We will find out if a version is missing as soon as anybody that doesn't have his version listed uses most of the the libremarkable based binaries.
 - One location where all device strings can be collected and every rust based app can profit of it.

Disadvantages:
 - Accessing `libremarkable::device::CURRENT_DEVICE` on a unsupported device will fail with the panic `Failed to determine model!` instead of having a hand-able case with a custom error message (the actual model is currently not shown in the panic). *1 *2
 - When someone finds that the *restream* binary fails for him because of the model, it can take a few more days to get fixed since it would need a PR to libremarkable which is then used again in reStream (though using the git repo with the fixed libremarkable/PR can eliminate this)
 - Using libremarkable multiplies the dependencies to the rust project considerably which increases the initial compilation time. Though the final binary if only 14KB bigger (aprox 0.4%).

*2 This was my initial design. I see this can be improved. Some ideas would be simply making `Model::current_model()` pub or handling the `Unknown` model variant in later functions in device and not failing upon creation. I used the `Unknown` variant since it is used everywhere else in the lib as well, but think I may have done a poor choice in using this variant. Feel free to fix it in a PR to libremarkable.

If you would rather handle the versioning yourself, just tell me and I'll add the extra version name instead of using libremarkable here. As said in the title, it is debatable since adding a full fat library for such a simple task can very well be considered overkill.

---

Side note 1: I would probably be best practice to add the Cargo.lock file as well. This is useful when someone will try to builds this a couple of years in the future and can't since he doesn't know the specific versions used. The general wisdom in rust is, that libs do not check this file in but bins do as far as I understand it.

Side note 2: Maybe it's worth here to strip the binary. Example: `source /usr/local/oecore-x86_64/environment-setup-cortexa9hf-neon-oe-linux-gnueabi && $STRIP target/armv7-unknown-linux-gnueabihf/release/restream`. This reduces the size from 3,4 MB to 354 KB (90%).

---

P.S.: Just wanted to say that I really appreciate this project. Before it came out, I did a few tests and thought that streaming videos was not doable since the processing would've been either too much or the bandwidth to low. The framerates you achieved by simply using lz4 blew my mind!