### PR TITLE
Add support for rm2fb

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,18 @@ reMarkable screen sharing over SSH.
 `apt install liblz4-tool` will do the trick.
 3. [Set up an SSH key and add it to the ssh-agent](https://help.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent), then add your key to the reMarkable with `ssh-copy-id root@10.11.99.1`.
 4. Copy the `restream` executable to the reMarkable and make it executable.
+
     ```
     # scp restream.arm.static root@10.11.99.1:/home/root/restream
     # ssh root@10.11.99.1 'chmod +x /home/root/restream'
+    ```
+
+    --or--
+
+    Install via [toltec](https://github.com/toltec-dev/toltec) if you use it (currently in the [testing branch](https://github.com/toltec-dev/toltec/blob/testing/docs/branches.md)).
+
+    ```
+    # ssh root@10.11.99.1 'opkg install restream'
     ```
 
 ## Usage
@@ -42,6 +51,7 @@ If you have problems, don't hesitate to [open an issue](https://github.com/rien/
 ## Requirements
 
 On your **host** machine:
+
 - Any POSIX-shell (e.g. bash)
 - ffmpeg (with ffplay)
 - ssh
@@ -59,13 +69,13 @@ apt install v4l2loopback-utils v4l2loopback-dkms
 
 In some package managers `v4l2loopback-utils` is found in `v4l-utils`.
 
-After installing the module you must enable it with 
+After installing the module you must enable it with
 
 ```
 modprobe v4l2loopback
 ```
 
-To verify that this worked, execute: 
+To verify that this worked, execute:
 
 ```
 v4l2-ctl --list-devices
@@ -76,6 +86,7 @@ The result should contain a line with "platform:v4l2loopback".
 ## Troubleshooting
 
 Steps you can try if the script isn't working:
+
 - [Set up an SSH key](#installation)
 - Update `ffmpeg` to version 4.
 

--- a/reStream.sh
+++ b/reStream.sh
@@ -96,10 +96,16 @@ case "$rm_version" in
         pixel_format="rgb565le"
         ;;
     "reMarkable 2.0")
-        pixel_format="gray8"
-        width=1872
-        height=1404
-        video_filters="$video_filters,transpose=2"
+        if ssh_cmd "[ -f /dev/shm/swtfb.01 ]"; then
+            width=1404
+            height=1872
+            pixel_format="rgb565le"
+        else
+            width=1872
+            height=1404
+            pixel_format="gray8"
+            video_filters="$video_filters,transpose=2"
+        fi
         ;;
     *)
         echo "Unsupported reMarkable version: $rm_version."
@@ -121,7 +127,7 @@ if ! lz4 -V >/dev/null; then
 fi
 
 # check if restream binay is present on remarkable
-if ssh_cmd "[ ! -f ~/restream ]"; then
+if ssh_cmd "[ ! -f ~/restream ] && [ ! -f /opt/bin/restream ]"; then
     echo "The restream binary is not installed on your reMarkable."
     echo "Please install it using the instruction in the README:"
     echo "https://github.com/rien/reStream/#installation"
@@ -178,7 +184,7 @@ fi
 set -e # stop if an error occurs
 
 # shellcheck disable=SC2086
-ssh_cmd "./restream" \
+ssh_cmd 'PATH="$PATH:/opt/bin/:." restream' \
     | $decompress \
     | $host_passthrough \
     | "$output_cmd" \

--- a/reStream.sh
+++ b/reStream.sh
@@ -183,7 +183,7 @@ fi
 
 set -e # stop if an error occurs
 
-# shellcheck disable=SC2086
+# shellcheck disable=SC2086,SC2016
 ssh_cmd 'PATH="$PATH:/opt/bin/:." restream' \
     | $decompress \
     | $host_passthrough \

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,25 +7,29 @@ use lz_fear::CompressionSettings;
 
 use std::default::Default;
 use std::fs::File;
+use std::path::Path;
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::process::Command;
 
 fn main() -> Result<()> {
     let version = remarkable_version()?;
+    let height = 1872;
     let streamer = if version == "reMarkable 1.0\n" {
         let width = 1408;
-        let height = 1872;
         let bytes_per_pixel = 2;
         ReStreamer::init("/dev/fb0", 0, width, height, bytes_per_pixel)?
     } else if version == "reMarkable 2.0\n" {
         let width = 1404;
-        let height = 1872;
-        let bytes_per_pixel = 1;
-
-        let pid = xochitl_pid()?;
-        let offset = rm2_fb_offset(pid)?;
-        let mem = format!("/proc/{}/mem", pid);
-        ReStreamer::init(&mem, offset, width, height, bytes_per_pixel)?
+        if Path::new("/dev/shm/swtfb.01").exists() {
+            let bytes_per_pixel = 2;
+            ReStreamer::init("/dev/shm/swtfb.01", 0, width, height, bytes_per_pixel)?
+        } else {
+            let bytes_per_pixel = 1;
+            let pid = xochitl_pid()?;
+            let offset = rm2_fb_offset(pid)?;
+            let mem = format!("/proc/{}/mem", pid);
+            ReStreamer::init(&mem, offset, width, height, bytes_per_pixel)?
+        }
     } else {
         Err(anyhow!(
             "Unknown reMarkable version: {}\nPlease open a feature request to support your device.",


### PR DESCRIPTION
This makes reStream work with [rm2fb](https://github.com/ddvk/remarkable2-framebuffer)

When installed, rm2fb creates /dev/shm/swtfb.01, which behaves very much like the old /dev/fb0 from the rm1. To get this working, a conditional check for this file was added both to the rust binary as well as the shell script.

Additionally, I've PR'd the rust helper binary into [toltec](https://github.com/toltec-dev/toltec). It has been accepted into testing. If installed via toltec, the rust helper binary will end up at `/opt/bin/restream`. I've also made two small changes to support this additional location for the helper.