### PR TITLE
Terminate script when ffmplay window closes

### DIFF
--- a/reStream.sh
+++ b/reStream.sh
@@ -183,7 +183,7 @@ set -e # stop if an error occurs
 ssh_cmd "./restream" \
     | $decompress \
     | $host_passthrough \
-    | "$output_cmd" \
+    | ("$output_cmd" \
         -vcodec rawvideo \
         -loglevel "$loglevel" \
         -f rawvideo \
@@ -191,4 +191,6 @@ ssh_cmd "./restream" \
         -video_size "$width,$height" \
         $window_title_option \
         -i - \
-        "$@"
+        "$@" \
+        ; kill $$
+    )


### PR DESCRIPTION
This PR should solve #42.

This currently only terminates the script on the host, but `restream` keeps running on the reMarkable (consuming a lot of resources). So we still need to find a way to correctly terminate the ssh session.