### PR TITLE
Fedora 33+ support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ On Ubuntu, `apt install liblz4-tool` will do the trick.
 2. [Set up an SSH key and add it to the ssh-agent](https://help.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent), then add your key to the reMarkable with `ssh-copy-id root@10.11.99.1`.  
 > **Note:** the reMarkable 2 doesn't support `ed25519` keys, those users should generate and `rsa` key. Try out `ssh root@10.11.99.1`, it should **not** prompt for a password.
 
+> **Note 2:** If you are using Fedora 33 or later, RSA keys are considered ["legacy"](https://fedoraproject.org/wiki/Changes/StrongCryptoSettings2) and will no longer work out of the box.
+> Therefore you need to add a section to your `~.ssh/config` file to allow use of RSA ssh keys for specified hosts.
+> This example should work without any config, although the identifier needs to be "remarkable" for the reStream to work correctly: 
+>```
+>   Host remarkable
+>	    HostName 10.11.99.1
+>	    User root
+>	    PubkeyAcceptedKeyTypes=ssh-rsa
+>```
+
 #### Windows
 
 1. Install [ffmpeg for windows](https://ffmpeg.org/download.html#build-windows).

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ On Ubuntu, `apt install liblz4-tool` will do the trick.
 
 > **Note 2:** If you are using Fedora 33 or later, RSA keys are considered ["legacy"](https://fedoraproject.org/wiki/Changes/StrongCryptoSettings2) and will no longer work out of the box.
 > Therefore you need to add a section to your `~.ssh/config` file to allow use of RSA ssh keys for specified hosts.
-> This example should work without any config, although the identifier needs to be "remarkable" for the reStream to work correctly: 
+> (according to [https://remarkablewiki.com/tech/ssh](https://remarkablewiki.com/tech/ssh), Remarkable devices might not work with non-RSA keys, which is the reason for why this is necessary.)
+> This example should work without any config, although the identifier needs to be "remarkable" with the line `PubkeyAcceptedKeyTypes=ssh-rsa` for the reStream to work correctly: 
 >```
 >   Host remarkable
 >	    HostName 10.11.99.1

--- a/README.md
+++ b/README.md
@@ -25,17 +25,6 @@ On Ubuntu, `apt install liblz4-tool` will do the trick.
 2. [Set up an SSH key and add it to the ssh-agent](https://help.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent), then add your key to the reMarkable with `ssh-copy-id root@10.11.99.1`.  
 > **Note:** the reMarkable 2 doesn't support `ed25519` keys, those users should generate and `rsa` key. Try out `ssh root@10.11.99.1`, it should **not** prompt for a password.
 
-> **Note 2:** If you are using Fedora 33 or later, RSA keys are considered ["legacy"](https://fedoraproject.org/wiki/Changes/StrongCryptoSettings2) and will no longer work out of the box.
-> Therefore you need to add a section to your `~.ssh/config` file to allow use of RSA ssh keys for specified hosts.
-> (according to [https://remarkablewiki.com/tech/ssh](https://remarkablewiki.com/tech/ssh), Remarkable devices might not work with non-RSA keys, which is the reason for why this is necessary.)
-> This example should work without any config, although the identifier needs to be "remarkable" with the line `PubkeyAcceptedKeyTypes=ssh-rsa` for the reStream to work correctly: 
->```
->   Host remarkable
->	    HostName 10.11.99.1
->	    User root
->	    PubkeyAcceptedKeyTypes=ssh-rsa
->```
-
 #### Windows
 
 1. Install [ffmpeg for windows](https://ffmpeg.org/download.html#build-windows).
@@ -162,6 +151,17 @@ Steps you can try if the script isn't working:
 
 - [Set up an SSH key](#installation)
 - Update `ffmpeg` to version 4.
+- Make sure RSA keys are allowed on your system:
+    - In some modern Unix distributions, RSA keys are considered ["legacy"](https://fedoraproject.org/wiki/Changes/StrongCryptoSettings2) and will no longer work out of the box.
+    - Therefore you need to add a section to your `~.ssh/config` file to allow use of RSA ssh keys for specified hosts. (according to [https://remarkablewiki.com/tech/ssh](https://remarkablewiki.com/tech/ssh), Remarkable devices might not work with non-RSA keys, which is the reason for why this is necessary.)
+    - This example should work without any additional configuration, although `PubkeyAcceptedKeyTypes=ssh-rsa` is required if you want to modify it: 
+        ```
+        Host remarkable
+            HostName 10.11.99.1
+            User root
+            PubkeyAcceptedKeyTypes=ssh-rsa
+        ```
+    - You can then use the -s flag to connect to the Remarkable: `./reStream.sh -s remarkable`
 
 ## Development
 

--- a/reStream.sh
+++ b/reStream.sh
@@ -94,12 +94,10 @@ ssh_cmd() {
         VER=$VERSION_ID
     fi
 
-	if [ "$OS" == "Fedora" ]; then
-        if [ "$VER" == "33" ]; then
-			ssh -o ConnectTimeout=1 -o PasswordAuthentication=no "remarkable" "$@"
-        fi
+	if [ "$OS" == "Fedora" ] && [ "$VER" == "33" ]; then
+		ssh -o ConnectTimeout=1 -o PasswordAuthentication=no "remarkable" "$@"
 	else
-			ssh -o ConnectTimeout=1 -o PasswordAuthentication=no "root@$remarkable" "$@"
+		ssh -o ConnectTimeout=1 -o PasswordAuthentication=no "root@$remarkable" "$@"
 	fi
 }
 

--- a/reStream.sh
+++ b/reStream.sh
@@ -90,7 +90,7 @@ ssh_cmd() {
 
     if [ -f /etc/os-release ]; then
         . /etc/os-release
-        OS=$NAME
+        OS=$NAME    
         VER=$VERSION_ID
     fi
 
@@ -104,7 +104,7 @@ ssh_cmd() {
 # check if we are able to reach the remarkable
 if ! ssh_cmd true; then
     echo "$remarkable unreachable or you have not set up an ssh key."
-    echo "If you see a 'Permission denied' error, please visit"
+    echo "If you see a 'Permission denied' error or is using Fedora 33+, please visit"
     echo "https://github.com/rien/reStream/#installation for instructions."
     exit 1
 fi

--- a/reStream.sh
+++ b/reStream.sh
@@ -94,10 +94,12 @@ ssh_cmd() {
         VER=$VERSION_ID
     fi
 
-	if [ "$OS" == "Fedora" ] && [ "$VER" == "33" ]; then
-		ssh -o ConnectTimeout=1 -o PasswordAuthentication=no "remarkable" "$@"
+	if [ "$OS" == "Fedora" ]; then
+        if [ "$VER" == "33" ]; then
+			ssh -o ConnectTimeout=1 -o PasswordAuthentication=no "remarkable" "$@"
+        fi
 	else
-		ssh -o ConnectTimeout=1 -o PasswordAuthentication=no "root@$remarkable" "$@"
+			ssh -o ConnectTimeout=1 -o PasswordAuthentication=no "root@$remarkable" "$@"
 	fi
 }
 

--- a/reStream.sh
+++ b/reStream.sh
@@ -90,7 +90,7 @@ ssh_cmd() {
 
     if [ -f /etc/os-release ]; then
         . /etc/os-release
-        OS=$NAME    
+        OS=$NAME
         VER=$VERSION_ID
     fi
 
@@ -104,7 +104,7 @@ ssh_cmd() {
 # check if we are able to reach the remarkable
 if ! ssh_cmd true; then
     echo "$remarkable unreachable or you have not set up an ssh key."
-    echo "If you see a 'Permission denied' error or is using Fedora 33+, please visit"
+    echo "If you see a 'Permission denied' error, please visit"
     echo "https://github.com/rien/reStream/#installation for instructions."
     exit 1
 fi

--- a/reStream.sh
+++ b/reStream.sh
@@ -83,24 +83,8 @@ while [ $# -gt 0 ]; do
 done
 
 ssh_cmd() {
-	OS=""
-	VER=""
-    
     echo "[SSH]" "$@" >&2
-
-    if [ -f /etc/os-release ]; then
-        . /etc/os-release
-        OS=$NAME
-        VER=$VERSION_ID
-    fi
-
-	if [ "$OS" == "Fedora" ]; then
-        if [ "$VER" == "33" ]; then
-			ssh -o ConnectTimeout=1 -o PasswordAuthentication=no "remarkable" "$@"
-        fi
-	else
-			ssh -o ConnectTimeout=1 -o PasswordAuthentication=no "root@$remarkable" "$@"
-	fi
+    ssh -o ConnectTimeout=1 -o PasswordAuthentication=no "root@$remarkable" "$@"
 }
 
 # check if we are able to reach the remarkable

--- a/reStream.sh
+++ b/reStream.sh
@@ -83,8 +83,24 @@ while [ $# -gt 0 ]; do
 done
 
 ssh_cmd() {
+	OS=""
+	VER=""
+    
     echo "[SSH]" "$@" >&2
-    ssh -o ConnectTimeout=1 -o PasswordAuthentication=no "root@$remarkable" "$@"
+
+    if [ -f /etc/os-release ]; then
+        . /etc/os-release
+        OS=$NAME
+        VER=$VERSION_ID
+    fi
+
+	if [ "$OS" == "Fedora" ]; then
+        if [ "$VER" == "33" ]; then
+			ssh -o ConnectTimeout=1 -o PasswordAuthentication=no "remarkable" "$@"
+        fi
+	else
+			ssh -o ConnectTimeout=1 -o PasswordAuthentication=no "root@$remarkable" "$@"
+	fi
 }
 
 # check if we are able to reach the remarkable


### PR DESCRIPTION
This is a small change to make reStream work better on systems running Fedora 33+.

The reason for this change is Fedora changing crypto policies for RSA keys, 
and reStream not having any option to work around this.
While it is possible to allow RSA key use for any remote hosts through system config files, it is considered unsafe by Fedora.
Allowing it for the remarkable device only is a better solution, but requires extra input from user. (editing the `~.ssh/config` file)