### PR TITLE
Instructions for building using docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,4 +154,18 @@ Steps you can try if the script isn't working:
 
 ## Development
 
-If you want to play with the `restream` code, you will have to [install Rust](https://www.rust-lang.org/learn/get-started) and [setup the reMarkable toolchain](https://github.com/canselcik/libremarkable#setting-up-the-toolchain) to do cross-platform development.
+If you want to play with the `restream` code, you will have to [install Rust](https://www.rust-lang.org/learn/get-started).
+
+There are two ways of building the required restream binary for streaming the reMarkable framebuffer. For both approaches, the generated restream binary will be located under `target/armv7-unknown-linux-gnueabihf/release/restream`.
+
+- Using docker and the toltec toolchain
+
+You can use the [toltec toolchain docker images](https://github.com/toltec-dev/toolchain) to build a restream binary compatible with the reMarkable.
+
+```
+docker run --rm -v $(pwd):/project -v /project/.cargo -w "/project" ghcr.io/toltec-dev/rust:latest cargo build --release --target=armv7-unknown-linux-gnueabihf
+```
+
+- Using the reMarkable toolchain 
+
+[Setup the reMarkable toolchain](https://github.com/canselcik/libremarkable#setting-up-the-toolchain) to do cross-platform development.


### PR DESCRIPTION
I first tried installing the required toolchain from reMarkable engineering, but the original installation script was taken down and the available options I found (https://remarkablewiki.com/devel/toolchain) didn't work for me as I couldn't get the toolchain installed (tried on macOS and linux).

I found the toltec toolchain docker images and ended up using docker to build the binary in macOS, which was much simpler than trying to manually install the toolchain. This PR adds the required instructions to do so, which will hopefully simplify development of reStream for newcomers.