### PR TITLE
Kill the process on remarkable at the end

### DIFF
--- a/reStream.sh
+++ b/reStream.sh
@@ -93,6 +93,13 @@ ssh_cmd() {
     ssh -o ConnectTimeout=1 -o PasswordAuthentication=no "root@$remarkable" "$@"
 }
 
+# kill reStream on remarkable at the end.
+# shellcheck disable=SC2016
+exit_rm() {
+    ssh_cmd 'kill $(pidof restream)'
+}
+trap exit_rm EXIT INT HUP
+
 # SSH_CONNECTION is a variable on reMarkable => ssh '' instead of ssh ""
 # shellcheck disable=SC2016
 remarkable_ip() {


### PR DESCRIPTION
As mentioned by @Deckweiss in #66, restream on remarkable is still alive after the script end. 
This is idea, but in a POSIX way.