### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM debian:bullseye-slim
+RUN apt-get -y update
+RUN apt-get -y upgrade
+RUN apt-get -y install ffmpeg liblz4-tool pv ssh
+RUN apt-get clean
+RUN mkdir -p /root/.ssh
+RUN echo "StrictHostKeyChecking no" > /root/.ssh/config
+COPY reStream.sh /
+ENTRYPOINT ["/reStream.sh"]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ On your **host** machine
 - ssh
 - lz4
 
+Alternatively you can run reStream in a Docker container which comes with above dependencies pre-installed.
+
 #### Unix
 
 1. Install `lz4` on your host with your usual package manager.   
@@ -38,6 +40,15 @@ On Ubuntu, `apt install liblz4-tool` will do the trick.
 5. Generate a new ssh-key using `ssh-keygen`.
 6. Send the public key to the reMarkable (connect trough USB cable) using `ssh-copy-id -i ~/.ssh/id_rsa root@10.11.99.1`
 7. Try out `ssh root@10.11.99.1`, it should **not** prompt for a password.
+
+#### Using Docker
+
+1. [Install Docker](https://docs.docker.com/get-docker/) if you haven't already.
+2. Make sure your host system can connect to your reMarkable via `ssh`.
+Therefore follow the above installation instructions for the SSH setup depending on your operating system.
+3. Non-Unix users need to install an X server compatibility layer.
+    - Windows WSL2 users install [VcXsrv](https://sourceforge.net/projects/vcxsrv/) and check all extra settings including "disable access control".
+    - macOS users install [XQuartz](https://www.xquartz.org/), open its preferences and check "Allow connections from network clients" in the security tab.
 
 ### reStream installation
 
@@ -105,6 +116,12 @@ $ ssh root@10.11.99.1 'chmod +x /home/root/restream'
 - `-u --unsecure-connection`: send framebuffer data over an unencrypted TCP-connection, resulting in more fps and less load on the reMarkable. See [Netcat](#netcat) for installation instructions.
 
 If you have problems, don't hesitate to [open an issue](https://github.com/rien/reStream/issues/new) or [send me an email](mailto:rien.maertens@posteo.be).
+
+### Running reStream via Docker
+
+Simply run `./docker.sh` instead of `./reStream.sh`.
+You can still append options as necessary, for example `./docker.sh -p -m`.
+Note that some options such as `--webcam` or `--output` are not yet supported when running reStream within Docker.
 
 ## Extra Dependencies
 

--- a/docker.sh
+++ b/docker.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  xhost local:root
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  DISPLAY="host.docker.internal:0"
+  xhost +localhost
+elif [[ "$OSTYPE" =~ ^cygwin|msys$ ]]; then
+  DISPLAY="$(route.exe print | grep 0.0.0.0 | head -1 | awk '{print $4}'):0.0"
+fi
+
+docker build -t restream .
+docker run \
+  --env DISPLAY=$DISPLAY \
+  --env SSH_AUTH_SOCK=/ssh-agent \
+  --network host \
+  --volume /tmp/.X11-unix:/tmp/.X11-unix \
+  --volume $SSH_AUTH_SOCK:/ssh-agent \
+  -it \
+  restream "$@"


### PR DESCRIPTION
This MR adds support for running reStream within a Docker container so that the prerequisites don't need to be installed on the host system.

Windows and macOS need to install an X server compatibility layer while Unix-like OSes have the X system already installed.

The readme file is updated to document the docker usage.