### PR TITLE
Release EXIT signal trap if SSH failed.

### DIFF
--- a/reStream.sh
+++ b/reStream.sh
@@ -119,9 +119,7 @@ remarkable_ip() {
 
 # check if we are able to reach the remarkable
 if ! ssh_cmd true; then
-    echo "$remarkable unreachable or you have not set up an ssh key."
-    echo "If you see a 'Permission denied' error, please visit"
-    echo "https://github.com/rien/reStream/#installation for instructions."
+    trap - EXIT
     exit 1
 fi
 


### PR DESCRIPTION
`ssh` access should not be attempted again if the reason the program is exiting is because `ssh` access failed.

I also think that the program should not print help messages to `stdout` when it is behaving under normal parameters. The error message received from `ssh` is self-explanatory. 