### PR TITLE
Added brightness changes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -13,6 +13,7 @@
         shellcheck
         shfmt
         lz4
+        ffmpeg_6-full
       ];
       CARGO_BUILD_TARGET="armv7-unknown-linux-gnueabihf";
       CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER="${pkgs.remarkable-toolchain}/sysroots/x86_64-codexsdk-linux/usr/bin/arm-remarkable-linux-gnueabi/arm-remarkable-linux-gnueabi-gcc";

--- a/reStream.sh
+++ b/reStream.sh
@@ -4,16 +4,16 @@
 version="1.2.0"
 
 # default values for arguments
-remarkable="${REMARKABLE_IP:-10.11.99.1}" # remarkable IP address
-landscape=true                            # rotate 90 degrees to the right
-output_path=-                             # display output through ffplay
-format=-                                  # automatic output format
-webcam=false                              # not to a webcam
-hflip=false                               # horizontal flip webcam
-measure_throughput=false                  # measure how fast data is being transferred
-window_title=reStream                     # stream window title is reStream
-video_filters=""                          # list of ffmpeg filters to apply
-unsecure_connection=false                 # Establish a unsecure connection that is faster
+remarkable="${REMARKABLE_IP:-10.11.99.1}"   # remarkable IP address
+landscape=true                              # rotate 90 degrees to the right
+output_path=-                               # display output through ffplay
+format=-                                    # automatic output format
+webcam=false                                # not to a webcam
+hflip=false                                 # horizontal flip webcam
+measure_throughput=false                    # measure how fast data is being transferred
+window_title=reStream                       # stream window title is reStream
+video_filters="curves=all='0/0 0.07/1 1/1'" # list of ffmpeg filters to apply
+unsecure_connection=false                   # Establish a unsecure connection that is faster
 
 # loop through arguments and process them
 while [ $# -gt 0 ]; do

--- a/reStream.sh
+++ b/reStream.sh
@@ -127,6 +127,8 @@ fi
 
 rm_version="$(ssh_cmd cat /sys/devices/soc0/machine)"
 
+echo $rm_version
+
 case "$rm_version" in
     "reMarkable 1.0")
         width=1408
@@ -141,14 +143,17 @@ case "$rm_version" in
             height=1872
             bytes_per_pixel=2
             fb_file="/dev/shm/swtfb.01"
-            pixel_format="rgb565le"
+            # pixel_format="rgb565le"
+            pixel_format="gray16be"
+            video_filters="$video_filters,transpose=3"
         else
             width=1872
             height=1404
-            bytes_per_pixel=1
+            bytes_per_pixel=2
             fb_file=":mem:"
-            pixel_format="gray8"
-            video_filters="$video_filters,transpose=2"
+            # pixel_format="gray8"
+            pixel_format="gray16be"
+            video_filters="$video_filters,transpose=3"
         fi
         ;;
     *)


### PR DESCRIPTION
In recent rm2fb versions, reStream output is too dark to be useful. This PR adds a filter suggested by @D1mme and fixes #91 