### PR TITLE
Fix Help Text Formatting

### DIFF
--- a/reStream.sh
+++ b/reStream.sh
@@ -83,13 +83,13 @@ while [ $# -gt 0 ]; do
         -h | --help | *)
             echo "Usage: $0 [-p] [-u] [-s <source>] [-o <output>] [-f <format>] [-t <title>] [-m] [-w] [--hflip]"
             echo "Examples:"
-            echo "	$0                              # live view in landscape"
-            echo "	$0 -p                           # live view in portrait"
-            echo "	$0 -s 192.168.0.10              # connect to different IP"
-            echo "	$0 -o remarkable.mp4            # record to a file"
-            echo "	$0 -o udp://dest:1234 -f mpegts # record to a stream"
-            echo "	$0 -w --mirror                  # write to a webcam (yuv420p + resize + mirror)"
-            echo "	$0 -u                           # establish a unsecure but faster connection"
+            echo "	$0                               # live view in landscape"
+            echo "	$0 -p                            # live view in portrait"
+            echo "	$0 -s 192.168.0.10               # connect to different IP"
+            echo "	$0 -o remarkable.mp4             # record to a file"
+            echo "	$0 -o udp://dest:1234 -f mpegts  # record to a stream"
+            echo "	$0 -w --mirror                   # write to a webcam (yuv420p + resize + mirror)"
+            echo "	$0 -u                            # establish a unsecure but faster connection"
             exit 1
             ;;
     esac


### PR DESCRIPTION
When packaging reStream for Fedora, we run `help2man` to generate a man page. This is currently having issues parsing the output from `--help`, adding the double space helps it to understand.