### PR TITLE
Rescaled grey16be colors using ffmpegs colorlevels to directly correct the original issue

### DIFF
--- a/reStream.sh
+++ b/reStream.sh
@@ -170,7 +170,7 @@ case "$rm_version" in
                 echo "Using the newer :mem: video settings."
                 bytes_per_pixel=2
                 pixel_format="gray16be"
-                video_filters="$video_filters eq=gamma=0.125:brightness=0.825,transpose=3"
+                video_filters="$video_filters colorlevels=rimin=0:rimax=29/255:gimin=0:gimax=29/255:bimin=0:bimax=29/255,transpose=3"
             # Use the previous video settings.
             else
                 echo "Using the older :mem: video settings."


### PR DESCRIPTION
This PR re-scales the `grey16be` colors using `ffmpeg`'s [`colorlevels`](https://ffmpeg.org/ffmpeg-filters.html#colorlevels) filter to directly reverse the original issue causing the image to be really dark.

Importantly, using this method the quality of small details is preserved, as opposed to `gamma`, `brightness` and `contrast` filters which significantly reduce the quality of text and small details and/or do not achieve the desired brightening effect.

Current solution on `main` since #100:

![Screenshot from 2024-01-09 19-31-33](https://github.com/rien/reStream/assets/2123767/54749009-d516-40e4-8fb2-1f713c3dec27)

Improved version with `colorlevels`:

![Screenshot from 2024-01-09 20-23-03](https://github.com/rien/reStream/assets/2123767/61998569-52ca-4d4f-bea2-b1cc619ea0c1)

Fixes: #96 
