### PR TITLE
Extra filters option

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ $ ssh root@10.11.99.1 'chmod +x /home/root/restream'
 - `-m --measure`: use `pv` to measure how much data throughput you have (good to experiment with parameters to speed up the pipeline)
 - `-t --title`: set a custom window title for the video stream. The default title is "reStream". This option is disabled when using `-o --output`
 - `-u --unsecure-connection`: send framebuffer data over an unencrypted TCP-connection, resulting in more fps and less load on the reMarkable. See [Netcat](#netcat) for installation instructions.
+- `-e --extra-filters`: pass extra video-filters to ffplay/ffmpeg (pass as a comma-seperated list)
 
 If you have problems, don't hesitate to [open an issue](https://github.com/rien/reStream/issues/new) or [send me an email](mailto:rien.maertens@posteo.be).
 

--- a/reStream.sh
+++ b/reStream.sh
@@ -21,6 +21,7 @@ measure_throughput=false                  # measure how fast data is being trans
 window_title=reStream                     # stream window title is reStream
 video_filters=""                          # list of ffmpeg filters to apply
 unsecure_connection=false                 # Establish a unsecure connection that is faster
+extra_video_filters=""                    # Extra video filters to add at the end
 
 # loop through arguments and process them
 while [ $# -gt 0 ]; do
@@ -44,6 +45,11 @@ while [ $# -gt 0 ]; do
             ;;
         -o | --output)
             output_path="$2"
+            shift
+            shift
+            ;;
+        -e | --extra-filters)
+            extra_video_filters="$2"
             shift
             shift
             ;;
@@ -170,7 +176,9 @@ case "$rm_version" in
                 echo "Using the newer :mem: video settings."
                 bytes_per_pixel=2
                 pixel_format="gray16be"
-                video_filters="$video_filters,colorlevels=rimin=0:rimax=29/255:gimin=0:gimax=29/255:bimin=0:bimax=29/255,transpose=3"
+                # NOTE: It seems simpler to use curves, and it achieves the same
+                # video_filters="$video_filters,colorlevels=rimin=0:rimax=29/255:gimin=0:gimax=29/255:bimin=0:bimax=29/255,transpose=3"
+                video_filters="$video_filters,curves=all='0/0 0.125/1 1/1',transpose=3"
             # Use the previous video settings.
             else
                 echo "Using the older :mem: video settings."
@@ -242,7 +250,7 @@ fi
 # set each frame presentation time to the time it is received
 video_filters="$video_filters,setpts=(RTCTIME - RTCSTART) / (TB * 1000000)"
 
-set -- "$@" -vf "${video_filters#,}"
+set -- "$@" -vf "${video_filters#,},${extra_video_filters}"
 
 if [ "$output_path" = - ]; then
     output_cmd=ffplay

--- a/reStream.sh
+++ b/reStream.sh
@@ -170,7 +170,7 @@ case "$rm_version" in
                 echo "Using the newer :mem: video settings."
                 bytes_per_pixel=2
                 pixel_format="gray16be"
-                video_filters="$video_filters colorlevels=rimin=0:rimax=29/255:gimin=0:gimax=29/255:bimin=0:bimax=29/255,transpose=3"
+                video_filters="$video_filters,colorlevels=rimin=0:rimax=29/255:gimin=0:gimax=29/255:bimin=0:bimax=29/255,transpose=3"
             # Use the previous video settings.
             else
                 echo "Using the older :mem: video settings."

--- a/reStream.sh
+++ b/reStream.sh
@@ -176,8 +176,10 @@ case "$rm_version" in
                 echo "Using the newer :mem: video settings."
                 bytes_per_pixel=2
                 pixel_format="gray16be"
-                # NOTE: It seems simpler to use curves, and it achieves the same
-                # video_filters="$video_filters,colorlevels=rimin=0:rimax=29/255:gimin=0:gimax=29/255:bimin=0:bimax=29/255,transpose=3"
+                # "curves" modifies the intensity of an RGB-value.
+                # The remarkable's max output is 1/8th of the normal brightness
+                # so the curves filter sets the scale from 0 -> 1 to 0 -> 0.125
+                # (https://ffmpeg.org/ffmpeg-filters.html#toc-Examples-63)
                 video_filters="$video_filters,curves=all='0/0 0.125/1 1/1',transpose=3"
             # Use the previous video settings.
             else


### PR DESCRIPTION
Implements the `-e | --extra-filters` proposed in #70 .

This will add the filter at the end of the program-set filters, because when testing with "negate" (#69 ), this seems to be the safer way.

Also fixed a missing comma (see fist commit)

Examples:
`reStream.sh -e "avgblur=sizeX=12"`
![image](https://github.com/user-attachments/assets/800dad6f-5c96-485e-ab8d-e98f6e90bb65)

`reStream.sh -e "negate"`
![image](https://github.com/user-attachments/assets/2cdda70a-b13b-444f-acbb-881e9b21f032)

`reStream.sh -e "lutrgb=r='if(gte(val,0)*lte(val,85),255,0)':g='if(gte(val,85)*lte(val,170),255,0)':b='if(gte(val,170)*lte(val,255),255,0)'"`
![image](https://github.com/user-attachments/assets/f898ab81-9499-4ad7-934e-6881970b9d75)
(I'll experiment to see if is possible to let ffmpeg convert grayscale to some simple colours on the fly)


Arguments should be comma-seperated. I don't know if it would be necessary to add a check in the shell-script to see if it is valid output, or if we would just let it fail and let the user figure out what exactly went wrong.


The reason this is a draft PR, is for the above reason, and because I altered the way brightness is controlled. Instead of setting the max colorlevels for each color to 1/8th of their max (29/255), I used the curves filter to set the threshold at 1/8 = 0.125. The result looks the same, but it reads easier. I would like feedback about that.


Closes #70 