### PR TITLE
prevent empty vfilter

### DIFF
--- a/reStream.sh
+++ b/reStream.sh
@@ -251,8 +251,7 @@ fi
 
 # set each frame presentation time to the time it is received
 video_filters="$video_filters,setpts=(RTCTIME - RTCSTART) / (TB * 1000000)"
-
-set -- "$@" -vf "${video_filters#,},${extra_video_filters}"
+set -- "$@" -vf "${video_filters#,}${extra_video_filters:+,}${extra_video_filters}"
 
 if [ "$output_path" = - ]; then
     output_cmd=ffplay


### PR DESCRIPTION
The current code adds a trailing comma in case no extra video filters are defined. At least with my version of ffmpeg (5.1.6-0+deb12u1) this does not work and leads to:

No such filter: ''

Which is: ffmpeg interprets the (empty) part after the comma as filter and does not have such a filter.

The patch only adds the comma if the extra filters are defined and are not empty.