### PR TITLE
Add TERM signal to exit_rm trap

### DIFF
--- a/reStream.sh
+++ b/reStream.sh
@@ -140,7 +140,7 @@ is_current_rm_firmware_version_ge() {
 exit_rm() {
     ssh_cmd 'kill $(pidof restream)'
 }
-trap exit_rm EXIT INT HUP
+trap exit_rm EXIT INT HUP TERM
 
 # SSH_CONNECTION is a variable on reMarkable => ssh '' instead of ssh ""
 # shellcheck disable=SC2016


### PR DESCRIPTION
Fixes the trap so that if reStream is killed from the terminal, the process will also exit on the device rather than leaving an orphaned process.