### PR TITLE
Version for myself

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ $ ssh root@10.11.99.1 'chmod +x /home/root/restream'
 - `-u --unsecure-connection`: send framebuffer data over an unencrypted TCP-connection, resulting in more fps and less load on the reMarkable. See [Netcat](#netcat) for installation instructions.
 - `-e --extra-filters`: pass extra video-filters to ffplay/ffmpeg (pass as a comma-seperated list)
 - `-d --dark-mode`: Dark mode. Make background black and text white.
+- `--grey`: Grey e-ink display mode (applies grey filter to the white or dark mode)
 
 If you have problems, don't hesitate to [open an issue](https://github.com/rien/reStream/issues/new) or [send me an email](mailto:rien.maertens@posteo.be).
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ $ ssh root@10.11.99.1 'chmod +x /home/root/restream'
 - `-u --unsecure-connection`: send framebuffer data over an unencrypted TCP-connection, resulting in more fps and less load on the reMarkable. See [Netcat](#netcat) for installation instructions.
 - `-e --extra-filters`: pass extra video-filters to ffplay/ffmpeg (pass as a comma-seperated list)
 - `-d --dark-mode`: Dark mode. Make background black and text white.
-- `--crop`: Crop the Remarkable toolbar
+- `--crop`: Crop the Remarkable toolbar (enabled by default)
+- `--no-crop`: Do not crop the Remarkable toolbar
 - `--grey`: Grey e-ink display mode (applies grey filter to the white or dark mode)
 
 If you have problems, don't hesitate to [open an issue](https://github.com/rien/reStream/issues/new) or [send me an email](mailto:rien.maertens@posteo.be).

--- a/README.md
+++ b/README.md
@@ -99,18 +99,21 @@ $ ssh root@10.11.99.1 'chmod +x /home/root/restream'
 
 ### Options
 
+- `[IP]`: positional argument specifying the reMarkable IP address (alternative to `-s`)
 - `-h --help`: show usage information
-- `-p --portrait`: shows the reMarkable screen in portrait mode (default: landscape mode, 90 degrees rotated tot the right)
+- `-p --portrait`: shows the reMarkable screen in portrait mode (default: landscape mode, 90 degrees rotated to the right)
+- `-l --landscape`: shows the reMarkable screen in landscape mode
 - `-s --source`: the ssh destination of the reMarkable (default: `root@10.11.99.1`)
+- `-i --identity`: path to the SSH private key file (default: `~/V/aws/remarkable`)
 - `-o --output`: path of the output where the video should be recorded, as understood by `ffmpeg`; if this is `-`, the video is displayed in a new window and not recorded anywhere (default: `-`)
-- `-f --format`: when recording to an output, this option is used to force the encoding format; if this is `-`, `ffmpeg`’s auto format detection based on the file extension is used (default: `-`).
+- `-f --format`: when recording to an output, this option is used to force the encoding format; if this is `-`, `ffmpeg`'s auto format detection based on the file extension is used (default: `-`).
 - `-w --webcam`: record to a video4linux2 web cam device. By default the first found web cam is taken, this can be overwritten with `-o`. The video is scaled to 1280x720 to ensure compatibility with MS Teams, Skype for business and other programs which need this specific format. See [Video4Linux Loopback](#video4linux-loopback) for installation instructions.
 - `--mirror`: mirror the web cam video (`--webcam` has to be set). By default or as only choice, some programs, such as Zoom and Discord, mirror the camera. This flag restores the correct orientation.
 - `-m --measure`: use `pv` to measure how much data throughput you have (good to experiment with parameters to speed up the pipeline)
 - `-t --title`: set a custom window title for the video stream. The default title is "reStream". This option is disabled when using `-o --output`
 - `-u --unsecure-connection`: send framebuffer data over an unencrypted TCP-connection, resulting in more fps and less load on the reMarkable. See [Netcat](#netcat) for installation instructions.
 - `-e --extra-filters`: pass extra video-filters to ffplay/ffmpeg (pass as a comma-seperated list)
-- `--dark-mode`: Dark mode. Make background black and text white.
+- `-d --dark-mode`: Dark mode. Make background black and text white.
 
 If you have problems, don't hesitate to [open an issue](https://github.com/rien/reStream/issues/new) or [send me an email](mailto:rien.maertens@posteo.be).
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ $ ssh root@10.11.99.1 'chmod +x /home/root/restream'
 - `-u --unsecure-connection`: send framebuffer data over an unencrypted TCP-connection, resulting in more fps and less load on the reMarkable. See [Netcat](#netcat) for installation instructions.
 - `-e --extra-filters`: pass extra video-filters to ffplay/ffmpeg (pass as a comma-seperated list)
 - `-d --dark-mode`: Dark mode. Make background black and text white.
+- `--crop`: Crop the Remarkable toolbar
 - `--grey`: Grey e-ink display mode (applies grey filter to the white or dark mode)
 
 If you have problems, don't hesitate to [open an issue](https://github.com/rien/reStream/issues/new) or [send me an email](mailto:rien.maertens@posteo.be).

--- a/reStream.sh
+++ b/reStream.sh
@@ -24,7 +24,7 @@ window_title=reStream                     # stream window title is reStream
 video_filters=""                          # list of ffmpeg filters to apply
 unsecure_connection=false                 # Establish a unsecure connection that is faster
 extra_video_filters=""                    # Extra video filters to add at the end
-crop=false                                # Crop the Remarkable toolbar from the frame edge
+crop=true                                 # Crop the Remarkable toolbar from the frame edge
 dark_mode="${REMARKABLE_DARK:-false}"     # Dark mode
 ssh_key="${SSH_KEY:-~/.ssh/remarkable}"   # SSH key file
 
@@ -114,6 +114,10 @@ while [ $# -gt 0 ]; do
             crop=true
             shift
             ;;
+        --no-crop)
+            crop=false
+            shift
+            ;;
         --grey)
             extra_video_filters="${extra_video_filters:+$extra_video_filters,}eq=brightness=0.1:contrast=0.6"
             shift
@@ -124,7 +128,7 @@ while [ $# -gt 0 ]; do
             shift
             ;;
         -h | --help)
-            echo "Usage: $0 [IP] [-p] [-l] [-c] [-u] [-i <keyfile>] [-s <source>] [-o <output>] [-f <format>] [-t <title>] [-m] [-w] [-d] [--crop] [--grey] [--hflip]"
+            echo "Usage: $0 [IP] [-p] [-l] [-c] [-u] [-i <keyfile>] [-s <source>] [-o <output>] [-f <format>] [-t <title>] [-m] [-w] [-d] [--crop] [--no-crop] [--grey] [--hflip]"
             echo "Examples:"
             echo "	$0                               # live view in portrait (default)"
             echo "	$0 10.11.99.1                    # connect to specific IP (same as -s)"

--- a/reStream.sh
+++ b/reStream.sh
@@ -24,6 +24,7 @@ window_title=reStream                     # stream window title is reStream
 video_filters=""                          # list of ffmpeg filters to apply
 unsecure_connection=false                 # Establish a unsecure connection that is faster
 extra_video_filters=""                    # Extra video filters to add at the end
+crop=false                                # Crop the Remarkable toolbar from the frame edge
 dark_mode="${REMARKABLE_DARK:-false}"     # Dark mode
 ssh_key="${SSH_KEY:-~/.ssh/remarkable}"   # SSH key file
 
@@ -109,6 +110,10 @@ while [ $# -gt 0 ]; do
             dark_mode=true
             shift
             ;;
+        --crop)
+            crop=true
+            shift
+            ;;
         --grey)
             extra_video_filters="${extra_video_filters:+$extra_video_filters,}eq=brightness=0.1:contrast=0.6"
             shift
@@ -119,7 +124,7 @@ while [ $# -gt 0 ]; do
             shift
             ;;
         -h | --help)
-            echo "Usage: $0 [IP] [-p] [-l] [-c] [-u] [-i <keyfile>] [-s <source>] [-o <output>] [-f <format>] [-t <title>] [-m] [-w] [-d] [--grey] [--hflip]"
+            echo "Usage: $0 [IP] [-p] [-l] [-c] [-u] [-i <keyfile>] [-s <source>] [-o <output>] [-f <format>] [-t <title>] [-m] [-w] [-d] [--crop] [--grey] [--hflip]"
             echo "Examples:"
             echo "	$0                               # live view in portrait (default)"
             echo "	$0 10.11.99.1                    # connect to specific IP (same as -s)"
@@ -303,6 +308,15 @@ set --
 
 # rotate 90 degrees if landscape=true
 $landscape && video_filters="$video_filters,transpose=1"
+
+# Crop the Remarkable toolbar : crop 112 pixels from the edge of the frame
+if $crop; then
+    if $landscape; then
+        video_filters="$video_filters,crop=in_w:in_h-112:0:112"
+    else
+        video_filters="$video_filters,crop=in_w-112:in_h:112:0"
+    fi
+fi
 
 # Scale and add padding if we are targeting a webcam because a lot of services
 # expect a size of exactly 1280x720 (tested in Firefox, MS Teams, and Skype for

--- a/reStream.sh
+++ b/reStream.sh
@@ -13,7 +13,7 @@ rm2_firmware_version_3_27="3.27.1.0"
 
 # default values for arguments
 remarkable="${REMARKABLE_IP:-10.11.99.1}" # remarkable IP address
-landscape=true                            # rotate 90 degrees to the right
+landscape=false                           # rotate 90 degrees to the right
 cursor=false                              # show a cursor where the pen is hovering
 output_path=-                             # display output through ffplay
 format=-                                  # automatic output format
@@ -36,6 +36,10 @@ while [ $# -gt 0 ]; do
             ;;
         -p | --portrait)
             landscape=false
+            shift
+            ;;
+        -l | --landscape)
+            landscape=true
             shift
             ;;
         -c | --cursor)
@@ -111,10 +115,11 @@ while [ $# -gt 0 ]; do
             shift
             ;;
         -h | --help | *)
-            echo "Usage: $0 [-p] [-c] [-u] [-i <keyfile>] [-s <source>] [-o <output>] [-f <format>] [-t <title>] [-m] [-w] [-d] [--hflip]"
+            echo "Usage: $0 [-p] [-l] [-c] [-u] [-i <keyfile>] [-s <source>] [-o <output>] [-f <format>] [-t <title>] [-m] [-w] [-d] [--hflip]"
             echo "Examples:"
-            echo "	$0                               # live view in landscape"
+            echo "	$0                               # live view in portrait (default)"
             echo "	$0 -p                            # live view in portrait"
+            echo "	$0 -l                            # live view in landscape"
             echo "	$0 -c                            # show a cursor where the pen is hovering (rM2 only)"
             echo "	$0 -s 192.168.0.10               # connect to different IP"
             echo "	$0 -i ~/.ssh/reMarkable          # use specific SSH key"

--- a/reStream.sh
+++ b/reStream.sh
@@ -25,6 +25,7 @@ video_filters=""                          # list of ffmpeg filters to apply
 unsecure_connection=false                 # Establish a unsecure connection that is faster
 extra_video_filters=""                    # Extra video filters to add at the end
 dark_mode="${REMARKABLE_DARK:-false}"     # Dark mode
+ssh_key="${SSH_KEY:-~/.ssh/reMarkable}"   # SSH key file
 
 # loop through arguments and process them
 while [ $# -gt 0 ]; do
@@ -104,13 +105,19 @@ while [ $# -gt 0 ]; do
             dark_mode=true
             shift
             ;;
+        -i | --identity)
+            ssh_key="$2"
+            shift
+            shift
+            ;;
         -h | --help | *)
-            echo "Usage: $0 [-p] [-c] [-u] [-s <source>] [-o <output>] [-f <format>] [-t <title>] [-m] [-w] [-d] [--hflip]"
+            echo "Usage: $0 [-p] [-c] [-u] [-i <keyfile>] [-s <source>] [-o <output>] [-f <format>] [-t <title>] [-m] [-w] [-d] [--hflip]"
             echo "Examples:"
             echo "	$0                               # live view in landscape"
             echo "	$0 -p                            # live view in portrait"
             echo "	$0 -c                            # show a cursor where the pen is hovering (rM2 only)"
             echo "	$0 -s 192.168.0.10               # connect to different IP"
+            echo "	$0 -i ~/.ssh/reMarkable          # use specific SSH key"
             echo "	$0 -o remarkable.mp4             # record to a file"
             echo "	$0 -o udp://dest:1234 -f mpegts  # record to a stream"
             echo "	$0 -w --mirror                   # write to a webcam (yuv420p + resize + mirror)"
@@ -123,7 +130,7 @@ done
 
 ssh_cmd() {
     echo "[SSH]" "$@" >&2
-    ssh -o ConnectTimeout=1 \
+    ssh -i "$ssh_key" -o ConnectTimeout=1 \
         -o PasswordAuthentication=no \
         -o PubkeyAcceptedKeyTypes=+ssh-rsa \
         -o HostKeyAlgorithms=+ssh-rsa \
@@ -311,7 +318,9 @@ fi
 
 set -e # stop if an error occurs
 
-restream_options="-h $height -w $width -b $bytes_per_pixel -f $fb_file -s $skip_offset"
+#restream_options="-h $height -w $width -b $bytes_per_pixel -f $fb_file -s $skip_offset"
+# the -s parameter is unknown to the restream command
+restream_options="-h $height -w $width -b $bytes_per_pixel -f $fb_file"
 
 if "$cursor"; then
     restream_options="$restream_options -c"

--- a/reStream.sh
+++ b/reStream.sh
@@ -25,7 +25,7 @@ video_filters=""                          # list of ffmpeg filters to apply
 unsecure_connection=false                 # Establish a unsecure connection that is faster
 extra_video_filters=""                    # Extra video filters to add at the end
 dark_mode="${REMARKABLE_DARK:-false}"     # Dark mode
-ssh_key="${SSH_KEY:-~/.ssh/reMarkable}"   # SSH key file
+ssh_key="${SSH_KEY:-~/.ssh/remarkable}"   # SSH key file
 
 # loop through arguments and process them
 while [ $# -gt 0 ]; do
@@ -129,11 +129,14 @@ while [ $# -gt 0 ]; do
 done
 
 ssh_cmd() {
-    echo "[SSH]" "$@" >&2
+# added -o LogLevel=ERROR to suppresses the post-quantum key exchange warning 
+# by setting the SSH log level to ERROR only
+    echo "[SSH]" "$@" >&2	
     ssh -i "$ssh_key" -o ConnectTimeout=1 \
         -o PasswordAuthentication=no \
         -o PubkeyAcceptedKeyTypes=+ssh-rsa \
         -o HostKeyAlgorithms=+ssh-rsa \
+        -o LogLevel=ERROR \
         "root@$remarkable" "$@"
 }
 

--- a/reStream.sh
+++ b/reStream.sh
@@ -114,10 +114,11 @@ while [ $# -gt 0 ]; do
             shift
             shift
             ;;
-        -h | --help | *)
-            echo "Usage: $0 [-p] [-l] [-c] [-u] [-i <keyfile>] [-s <source>] [-o <output>] [-f <format>] [-t <title>] [-m] [-w] [-d] [--hflip]"
+        -h | --help)
+            echo "Usage: $0 [IP] [-p] [-l] [-c] [-u] [-i <keyfile>] [-s <source>] [-o <output>] [-f <format>] [-t <title>] [-m] [-w] [-d] [--hflip]"
             echo "Examples:"
             echo "	$0                               # live view in portrait (default)"
+            echo "	$0 10.11.99.1                    # connect to specific IP (same as -s)"
             echo "	$0 -p                            # live view in portrait"
             echo "	$0 -l                            # live view in landscape"
             echo "	$0 -c                            # show a cursor where the pen is hovering (rM2 only)"
@@ -130,8 +131,18 @@ while [ $# -gt 0 ]; do
             echo "	$0 -u                            # establish a unsecure but faster connection"
             exit 1
             ;;
+        *)
+            # Treat non-option argument as IP address
+            remarkable="$1"
+            shift
+            ;;
     esac
 done
+
+# If no IP was provided via -s or positional argument, use default
+if [ -z "$remarkable" ]; then
+    remarkable="${REMARKABLE_IP:-10.11.99.1}"
+fi
 
 ssh_cmd() {
 # added -o LogLevel=ERROR to suppresses the post-quantum key exchange warning 

--- a/reStream.sh
+++ b/reStream.sh
@@ -109,13 +109,17 @@ while [ $# -gt 0 ]; do
             dark_mode=true
             shift
             ;;
+        --grey)
+            extra_video_filters="${extra_video_filters:+$extra_video_filters,}eq=brightness=0.1:contrast=0.6"
+            shift
+            ;;
         -i | --identity)
             ssh_key="$2"
             shift
             shift
             ;;
         -h | --help)
-            echo "Usage: $0 [IP] [-p] [-l] [-c] [-u] [-i <keyfile>] [-s <source>] [-o <output>] [-f <format>] [-t <title>] [-m] [-w] [-d] [--hflip]"
+            echo "Usage: $0 [IP] [-p] [-l] [-c] [-u] [-i <keyfile>] [-s <source>] [-o <output>] [-f <format>] [-t <title>] [-m] [-w] [-d] [--grey] [--hflip]"
             echo "Examples:"
             echo "	$0                               # live view in portrait (default)"
             echo "	$0 10.11.99.1                    # connect to specific IP (same as -s)"
@@ -124,6 +128,7 @@ while [ $# -gt 0 ]; do
             echo "	$0 -c                            # show a cursor where the pen is hovering (rM2 only)"
             echo "	$0 -s 192.168.0.10               # connect to different IP"
             echo "	$0 -i ~/.ssh/reMarkable          # use specific SSH key"
+            echo "	$0 --grey                        # apply grey e-ink display mode (works in dark mode too)"
             echo "	$0 -o remarkable.mp4             # record to a file"
             echo "	$0 -o udp://dest:1234 -f mpegts  # record to a stream"
             echo "	$0 -w --mirror                   # write to a webcam (yuv420p + resize + mirror)"


### PR DESCRIPTION
I am quite sure it will be rejected (because there are several changes) but it is just for you to know: I could spend a bit more time to split the features in separate PRs (ie the `crop` & `grey` flags)

1. **Default orientation changed to portrait** — `landscape` default changed from `true` to [`false`](reStream.sh:16), making portrait mode the new default.

2. **New `-l --landscape` flag** — Added explicit option to switch back to landscape mode.

3. **New `--crop` and `--no-crop` flags** — Introduced toolbar cropping functionality (enabled by default). Cropping logic :
   - Landscape: crops 112 pixels from the bottom
   - Portrait: crops 112 pixels from the left

4. **New `--grey` flag** — Applies a grey e-ink display mode filter (`eq=brightness=0.1:contrast=0.6`).

5. **Positional IP address argument** — Non-option arguments are now treated as the reMarkable IP address (alternative to `-s`/`--source`).

6. **Updated help text** — Usage message expanded to document all new flags and updated examples reflecting the new portrait default.

7. **New `crop` variable** — Added `crop=true` default variable.

